### PR TITLE
subsquid support

### DIFF
--- a/rpc_configs/substrate.yml
+++ b/rpc_configs/substrate.yml
@@ -214,4 +214,5 @@ aliases:
   - [ chain_getBlockHash, chain_getHead ]
   - [ state_getKeysPaged, state_getKeysPagedAt ]
   - [ state_getStorage, state_getStorageAt ]
+  - [ state_getRuntimeVersion, chain_getRuntimeVersion ]
   - [ childstate_getKeysPaged, childstate_getKeysPagedAt ]


### PR DESCRIPTION
subsquid indexer and processor requires `chain_getRuntimeVersion` rpc to index the chain