### PR TITLE
chore: dudep middleware name

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -232,7 +232,9 @@ fn config() -> Config {
             ..Default::default()
         },
         middlewares: MiddlewaresConfig {
-            methods: vec!["inject_params".to_string(), "upstream".to_string()],
+            methods: vec!["inject_params".to_string(), "upstream".to_string()]
+                .into_iter()
+                .collect(),
             subscriptions: vec!["upstream".to_string()],
         },
         rpcs: RpcDefinitions {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{collections::BTreeSet, fs};
 
 use clap::Parser;
 use serde::Deserialize;
@@ -118,7 +118,7 @@ impl From<RpcOptions> for RpcDefinitions {
 
 #[derive(Deserialize, Debug)]
 pub struct MiddlewaresConfig {
-    pub methods: Vec<String>,
+    pub methods: BTreeSet<String>,
     pub subscriptions: Vec<String>,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -251,7 +251,7 @@ mod tests {
                 ..Default::default()
             },
             middlewares: MiddlewaresConfig {
-                methods: vec!["crazy".to_string(), "upstream".to_string()],
+                methods: vec!["crazy".to_string(), "upstream".to_string()].into_iter().collect(),
                 subscriptions: vec![],
             },
             rpcs: RpcDefinitions {

--- a/src/tests/merge_subscription.rs
+++ b/src/tests/merge_subscription.rs
@@ -64,7 +64,7 @@ async fn merge_subscription_works() {
             ..Default::default()
         },
         middlewares: MiddlewaresConfig {
-            methods: vec![],
+            methods: Default::default(),
             subscriptions: vec!["merge_subscription".to_string(), "upstream".to_string()],
         },
         rpcs: RpcDefinitions {

--- a/src/tests/upstream.rs
+++ b/src/tests/upstream.rs
@@ -46,7 +46,7 @@ async fn upstream_error_propagate() {
             ..Default::default()
         },
         middlewares: MiddlewaresConfig {
-            methods: vec![],
+            methods: Default::default(),
             subscriptions: vec!["merge_subscription".to_string(), "upstream".to_string()],
         },
         rpcs: RpcDefinitions {


### PR DESCRIPTION
Wonder if the middleware order should be kept ?