### PR TITLE
Set max batch size

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -222,6 +222,7 @@ fn config() -> Config {
                 listen_address: SUBWAY_SERVER_ADDR.to_string(),
                 port: SUBWAY_SERVER_PORT,
                 max_connections: 1024 * 1024,
+                max_batch_size: None,
                 request_timeout_seconds: 120,
                 http_methods: Vec::new(),
                 cors: None,

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -17,6 +17,7 @@ extensions:
     port: 9944
     listen_address: '0.0.0.0'
     max_connections: 2000
+    max_batch_size: 10
     http_methods:
       - path: /health
         method: system_health

--- a/configs/eth_config.yml
+++ b/configs/eth_config.yml
@@ -14,6 +14,7 @@ extensions:
     port: 8545
     listen_address: '0.0.0.0'
     max_connections: 2000
+    max_batch_size: 10
     cors: all
 
 middlewares:

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -4,8 +4,8 @@ use hyper::server::conn::AddrStream;
 use hyper::service::Service;
 use hyper::service::{make_service_fn, service_fn};
 use jsonrpsee::server::{
-    middleware::rpc::RpcServiceBuilder, stop_channel, ws, RandomStringIdProvider, RpcModule, ServerBuilder,
-    ServerHandle, BatchRequestConfig,
+    middleware::rpc::RpcServiceBuilder, stop_channel, ws, BatchRequestConfig, RandomStringIdProvider, RpcModule,
+    ServerBuilder, ServerHandle,
 };
 use jsonrpsee::Methods;
 

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -178,6 +178,7 @@ impl SubwayServerBuilder {
                         );
 
                     let batch_request_config = match config.max_batch_size {
+                        Some(0) => BatchRequestConfig::Disabled,
                         Some(max_size) => BatchRequestConfig::Limit(max_size),
                         None => BatchRequestConfig::Unlimited,
                     };

--- a/src/server.rs
+++ b/src/server.rs
@@ -436,12 +436,12 @@ mod tests {
     async fn batch_requests_disabled_errors() {
         let (endpoint, upstream_dummy_server_handle) = upstream_dummy_server("127.0.0.1:9959").await;
 
-        // Server with max batch size 3
+        // Server with max batch size 0 (disabled)
         let subway_server = subway_server(endpoint, 9948, None, Some(0)).await;
         let url = format!("ws://{}", subway_server.addr);
         let client = ws_client(&url).await;
 
-        // Sending 4 request in a batch
+        // Sending 1 request in a batch
         let mut batch = BatchRequestBuilder::new();
         batch.insert(PHO, rpc_params!()).unwrap();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,7 +427,7 @@ mod tests {
         // Checking if error is returned for now.
         let res = client.batch_request::<String>(batch).await;
 
-        assert_eq!(res.is_err(), true);
+        assert!(res.is_err());
 
         upstream_dummy_server_handle.stop().unwrap();
     }
@@ -453,9 +453,8 @@ mod tests {
         //
         // Checking if error is returned for now.
         let res = client.batch_request::<String>(batch).await;
-        println!("{:?}", res);
 
-        assert_eq!(res.is_err(), true);
+        assert!(res.is_err());
 
         upstream_dummy_server_handle.stop().unwrap();
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -255,6 +255,7 @@ mod tests {
                     listen_address: "127.0.0.1".to_string(),
                     port,
                     max_connections: 1024,
+                    max_batch_size: None,
                     request_timeout_seconds: request_timeout_seconds.unwrap_or(10),
                     http_methods: Vec::new(),
                     cors: None,

--- a/src/tests/merge_subscription.rs
+++ b/src/tests/merge_subscription.rs
@@ -54,6 +54,7 @@ async fn merge_subscription_works() {
                 listen_address: "0.0.0.0".to_string(),
                 port: 0,
                 max_connections: 10,
+                max_batch_size: None,
                 request_timeout_seconds: 120,
                 http_methods: Vec::new(),
                 cors: None,

--- a/src/tests/upstream.rs
+++ b/src/tests/upstream.rs
@@ -36,6 +36,7 @@ async fn upstream_error_propagate() {
                 listen_address: "0.0.0.0".to_string(),
                 port: 0,
                 max_connections: 10,
+                max_batch_size: None,
                 request_timeout_seconds: 120,
                 http_methods: Vec::new(),
                 cors: None,


### PR DESCRIPTION
Setting max batch size limit on RPC calls. Enabling jsonrpsee's functionality.
You will get jsonrpsee response `{"jsonrpc":"2.0","error":{"code":-32010,"message":"The batch request was too large","data":"Exceeded max limit of 3"},"id":null}` when requested batch exceeds the max batch size.

<img width="1170" alt="Screenshot 2024-05-20 at 16 52 49" src="https://github.com/AcalaNetwork/subway/assets/28953860/3b0bdceb-91fe-4c2e-9cf9-d097e534f7c3">

