### PR TITLE
Bump hyper version to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,9 +219,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -239,8 +245,8 @@ dependencies = [
  "async-trait",
  "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -261,12 +267,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -329,15 +329,6 @@ dependencies = [
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -466,6 +457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +560,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes 1.6.0",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -784,15 +791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1155,7 +1153,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 0.2.12",
  "js-sys",
  "pin-project",
  "serde",
@@ -1218,7 +1216,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.11",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.6.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1291,13 +1308,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.6.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.6.0",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes 1.6.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1335,9 +1386,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1350,19 +1401,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
  "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1371,10 +1445,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1549,6 +1643,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -1647,9 +1761,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1665,40 +1778,42 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http",
+ "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs 0.7.0",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-util 0.7.11",
  "tracing",
  "url",
- "webpki-roots",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
  "anyhow",
  "async-trait",
  "beef",
+ "bytes 1.6.0",
  "futures-timer",
  "futures-util",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.2",
  "pin-project",
@@ -1715,15 +1830,19 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
  "async-trait",
- "hyper",
+ "base64 0.22.1",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
  "hyper-rustls",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror",
@@ -1735,11 +1854,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1748,13 +1866,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
+ "anyhow",
  "futures-util",
- "http",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -1772,12 +1893,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
  "anyhow",
  "beef",
+ "http 1.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1785,9 +1906,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1796,11 +1916,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+version = "0.22.2"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
 dependencies = [
- "http",
+ "http 1.1.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2075,6 +2194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2211,15 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2137,12 +2275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,7 +2303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
 dependencies = [
  "futures-core",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "once_cell",
@@ -2193,7 +2325,7 @@ checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes 1.6.0",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "reqwest",
 ]
@@ -2281,7 +2413,7 @@ dependencies = [
  "mio 0.6.23",
  "mio-extras",
  "rand 0.7.3",
- "sha-1 0.8.2",
+ "sha-1",
  "slab",
  "url",
 ]
@@ -2783,10 +2915,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "ipnet",
  "js-sys",
  "log",
@@ -2885,40 +3017,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.3",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2928,19 +3037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2960,14 +3060,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "b5f0d26fa1ce3c790f9590868f0109289a044acb954525f933e2aa3b871c157d"
 dependencies = [
- "ring",
- "untrusted",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-webpki"
@@ -3017,16 +3134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3143,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -3126,20 +3234,18 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.1",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3190,18 +3296,18 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes 1.6.0",
  "futures",
- "http",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha1",
 ]
 
 [[package]]
@@ -3262,7 +3368,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8fe06b03b8a291c09507c42f92a2c2c10dd3d62975d02c7f64a92d87bfe09b"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "log",
  "prometheus",
  "thiserror",
@@ -3291,8 +3397,10 @@ dependencies = [
  "futures-util",
  "garde",
  "governor",
- "http",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
  "jsonrpc-http-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
@@ -3516,21 +3624,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3603,10 +3701,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes 1.6.0",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -3652,8 +3750,8 @@ dependencies = [
  "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "httpdate",
  "iri-string",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3410,7 +3410,6 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
- "hyper-util",
  "jsonrpc-http-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,8 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67210bd846b2dca59dc73f34717d6e1589305d506cdd6f14c849115d08e40876"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1778,8 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c171d64176ae8f57eec75bca9f9dda2b2f746314adef9160a5bbbb2a7c82cb"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -1802,8 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e966c12c8b6c1790ce67683c792cea9dd250860df49f6b64f1b1ff6c6946850"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1830,8 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0187f1969287e5890d84460fe9f6556d98231e70b06179d4416e5c8c47167d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1854,8 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7af1b5071dc1c61b06900f8f3e17f886b1b08e926166e575018643879f63b6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -1866,8 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba63ec742f5f9c4016ca4c443d04dc3ca56e240a26ebe6e56609a5109bd9d13f"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -1893,8 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c33717b7bdc4f47cdf31c21d5449c5b713a800cb05cb767841ccf2944f9d9"
 dependencies = [
  "anyhow",
  "beef",
@@ -1906,8 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1c1b2f71c32f763d85c1b9836c1a522377b3972177a76b3e66ba42f2582929"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1916,8 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb22661e1c018eb503d5a47be2d39a176de832b047d2757fa86b3d2b34fc84e"
 dependencies = [
  "http 1.1.0",
  "jsonrpsee-client-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-compression"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
  "brotli",
  "flate2",
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-client-transport"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-core"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-http-client"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-server"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-types"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "anyhow",
  "beef",
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-ws-client"
 version = "0.22.2"
-source = "git+https://github.com/paritytech/jsonrpsee?rev=038a77f#038a77ff4f5c5f3364b8be0d4c258fd75414df66"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=47f9c6c#47f9c6c806eecc8260b5cce148ee5b90ab500a1b"
 dependencies = [
  "http 1.1.0",
  "jsonrpsee-client-transport",
@@ -3401,6 +3401,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
+ "hyper-util",
  "jsonrpc-http-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
@@ -3740,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -3750,8 +3751,9 @@ dependencies = [
  "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "iri-string",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ enumflags2 = "0.7.7"
 futures = "0.3.25"
 http = "1"
 http-body = "1"
-http-body-util = "0.1.0"
+http-body-util = "0.1"
 hyper = "1.3"
+hyper-util = { version = "0.1.3", features = ["client", "client-legacy"]}
 moka = { version = "0.12", features = ["future"] }
 opentelemetry = { version = "0.21.0" }
 opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
@@ -41,13 +42,13 @@ serde_yaml = "0.9.17"
 substrate-prometheus-endpoint = "0.17.0"
 tokio = { version = "1.24.2", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.4", features = ["full"] }
+tower-http = { version = "0.5.2", features = ["full"] }
 tracing = "0.1.40"
 tracing-serde = "0.1.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 garde = { version = "0.18", features = ["full"] }
 
-jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee" , rev = "038a77f", features = ["full"] }
+jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", rev = "47f9c6c", features = ["full"] }
 governor = { path = "./vendor/governor/governor" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ http = "1"
 http-body = "1"
 http-body-util = "0.1"
 hyper = "1.3"
-hyper-util = { version = "0.1.3", features = ["client", "client-legacy"]}
 moka = { version = "0.12", features = ["future"] }
 opentelemetry = { version = "0.21.0" }
 opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing-serde = "0.1.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 garde = { version = "0.18", features = ["full"] }
 
-jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", rev = "47f9c6c", features = ["full"] }
+jsonrpsee = { version = "0.23", features = ["full"] }
 governor = { path = "./vendor/governor/governor" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ chrono = "0.4.24"
 clap = { version = "4.1.1", features = ["derive"] }
 enumflags2 = "0.7.7"
 futures = "0.3.25"
-http = "0.2"
-hyper = "0.14"
+http = "1"
+http-body = "1"
+http-body-util = "0.1.0"
+hyper = "1.3"
 moka = { version = "0.12", features = ["future"] }
 opentelemetry = { version = "0.21.0" }
 opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
@@ -45,7 +47,7 @@ tracing-serde = "0.1.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 garde = { version = "0.18", features = ["full"] }
 
-jsonrpsee = { version = "0.22.1",features = ["full"] }
+jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee" , rev = "038a77f", features = ["full"] }
 governor = { path = "./vendor/governor/governor" }
 
 [dev-dependencies]

--- a/benches/bench/helpers.rs
+++ b/benches/bench/helpers.rs
@@ -40,7 +40,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle, url: &str) -> (String, js
             SUB_METHOD_NAME,
             SUB_METHOD_NAME,
             UNSUB_METHOD_NAME,
-            |_params, pending, _ctx| async move {
+            |_params, pending, _ctx, _| async move {
                 let sink = pending.accept().await?;
                 let msg = SubscriptionMessage::from_json(&"Hello")?;
                 sink.send(msg).await?;
@@ -53,7 +53,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle, url: &str) -> (String, js
             "chain_subscribeNewHeads",
             "chain_newHead",
             "chain_unsubscribeNewHeads",
-            |_params, pending, _ctx| async move {
+            |_params, pending, _ctx, _| async move {
                 let sink = pending.accept().await?;
                 let msg = SubscriptionMessage::from_json(&serde_json::json!({ "number": "0x4321" }))?;
                 sink.send(msg).await?;
@@ -66,7 +66,7 @@ pub async fn ws_server(handle: tokio::runtime::Handle, url: &str) -> (String, js
             "chain_subscribeFinalizedHeads",
             "chain_finalizedHead",
             "chain_unsubscribeFinalizedHeads",
-            |_params, pending, _ctx| async move {
+            |_params, pending, _ctx, _| async move {
                 let sink = pending.accept().await?;
                 let msg = SubscriptionMessage::from_json(&serde_json::json!({ "number": "0x4321" }))?;
                 sink.send(msg).await?;
@@ -84,47 +84,47 @@ fn gen_rpc_module() -> jsonrpsee::RpcModule<()> {
     let mut module = jsonrpsee::RpcModule::new(());
 
     module
-        .register_method(SYNC_FAST_CALL, |_, _| Ok::<_, ErrorObjectOwned>("lo"))
+        .register_method(SYNC_FAST_CALL, |_, _, _| Ok::<_, ErrorObjectOwned>("lo"))
         .unwrap();
     module
-        .register_async_method(ASYNC_FAST_CALL, |_, _| async {
+        .register_async_method(ASYNC_FAST_CALL, |_, _, _| async {
             Result::<_, ErrorObjectOwned>::Ok("lo")
         })
         .unwrap();
 
     module
-        .register_method(SYNC_MEM_CALL, |_, _| Ok::<_, ErrorObjectOwned>("A".repeat(MIB)))
+        .register_method(SYNC_MEM_CALL, |_, _, _| Ok::<_, ErrorObjectOwned>("A".repeat(MIB)))
         .unwrap();
 
     module
-        .register_async_method(ASYNC_MEM_CALL, |_, _| async move {
+        .register_async_method(ASYNC_MEM_CALL, |_, _, _| async move {
             Result::<_, ErrorObjectOwned>::Ok("A".repeat(MIB))
         })
         .unwrap();
 
     module
-        .register_method(SYNC_SLOW_CALL, |_, _| {
+        .register_method(SYNC_SLOW_CALL, |_, _, _| {
             std::thread::sleep(SLOW_CALL);
             Ok::<_, ErrorObjectOwned>("slow call")
         })
         .unwrap();
 
     module
-        .register_async_method(ASYNC_SLOW_CALL, |_, _| async move {
+        .register_async_method(ASYNC_SLOW_CALL, |_, _, _| async move {
             tokio::time::sleep(SLOW_CALL).await;
             Result::<_, ErrorObjectOwned>::Ok("slow call async")
         })
         .unwrap();
 
     module
-        .register_async_method(ASYNC_INJECT_CALL, |_, _| async move {
+        .register_async_method(ASYNC_INJECT_CALL, |_, _, _| async move {
             tokio::time::sleep(SLOW_CALL).await;
             Result::<_, ErrorObjectOwned>::Ok("inject call async")
         })
         .unwrap();
 
     module
-        .register_async_method("chain_getBlockHash", |_, _| async move {
+        .register_async_method("chain_getBlockHash", |_, _, _| async move {
             tokio::time::sleep(SLOW_CALL).await;
             Result::<_, ErrorObjectOwned>::Ok("0x42")
         })

--- a/src/extensions/client/mock.rs
+++ b/src/extensions/client/mock.rs
@@ -34,7 +34,7 @@ impl TestServerBuilder {
     pub fn register_method(&mut self, name: &'static str) -> mpsc::Receiver<MockRequest> {
         let (tx, rx) = mpsc::channel::<MockRequest>(100);
         self.module
-            .register_async_method(name, move |params, _| {
+            .register_async_method(name, move |params, _, _| {
                 let tx = tx.clone();
                 let params = params.parse::<JsonValue>().unwrap();
                 async move {
@@ -56,7 +56,7 @@ impl TestServerBuilder {
     ) -> mpsc::Receiver<MockSubscription> {
         let (tx, rx) = mpsc::channel::<MockSubscription>(100);
         self.module
-            .register_subscription(sub_name, method_name, unsub_name, move |params, sink, _| {
+            .register_subscription(sub_name, method_name, unsub_name, move |params, sink, _, _| {
                 let tx = tx.clone();
                 let params = params.parse::<JsonValue>().unwrap();
                 tokio::spawn(async move {
@@ -76,7 +76,7 @@ impl TestServerBuilder {
         unsub_name: &'static str,
     ) {
         self.module
-            .register_subscription(sub_name, method_name, unsub_name, move |_, sink, _| async {
+            .register_subscription(sub_name, method_name, unsub_name, move |_, sink, _, _| async {
                 sink.reject(errors::map_error(Error::Call(ErrorObject::owned(
                     1010,
                     "Invalid Transaction",

--- a/src/extensions/client/mod.rs
+++ b/src/extensions/client/mod.rs
@@ -250,9 +250,7 @@ impl Client {
                                     Err(err) => {
                                         tracing::debug!("Request failed: {:?}", err);
                                         match err {
-                                            Error::RequestTimeout
-                                            | Error::Transport(_)
-                                            | Error::RestartNeeded(_) => {
+                                            Error::RequestTimeout | Error::Transport(_) | Error::RestartNeeded(_) => {
                                                 tokio::time::sleep(get_backoff_time(&request_backoff_counter)).await;
 
                                                 // make sure it's still connected
@@ -328,9 +326,7 @@ impl Client {
                                     Err(err) => {
                                         tracing::debug!("Subscribe failed: {:?}", err);
                                         match err {
-                                            Error::RequestTimeout
-                                            | Error::Transport(_)
-                                            | Error::RestartNeeded(_) => {
+                                            Error::RequestTimeout | Error::Transport(_) | Error::RestartNeeded(_) => {
                                                 tokio::time::sleep(get_backoff_time(&request_backoff_counter)).await;
 
                                                 // make sure it's still connected

--- a/src/extensions/client/mod.rs
+++ b/src/extensions/client/mod.rs
@@ -252,8 +252,7 @@ impl Client {
                                         match err {
                                             Error::RequestTimeout
                                             | Error::Transport(_)
-                                            | Error::RestartNeeded(_)
-                                            | Error::MaxSlotsExceeded => {
+                                            | Error::RestartNeeded(_) => {
                                                 tokio::time::sleep(get_backoff_time(&request_backoff_counter)).await;
 
                                                 // make sure it's still connected
@@ -331,8 +330,7 @@ impl Client {
                                         match err {
                                             Error::RequestTimeout
                                             | Error::Transport(_)
-                                            | Error::RestartNeeded(_)
-                                            | Error::MaxSlotsExceeded => {
+                                            | Error::RestartNeeded(_) => {
                                                 tokio::time::sleep(get_backoff_time(&request_backoff_counter)).await;
 
                                                 // make sure it's still connected

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -197,7 +197,6 @@ impl SubwayServerBuilder {
                 };
 
                 let per_conn2 = per_conn.clone();
-                // let call_metrics = rpc_metrics.clone().call_metrics();
 
                 // service_fn handle each connection
                 let svc = tower::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
@@ -242,7 +241,7 @@ impl SubwayServerBuilder {
                             });
                         }
 
-                        service.clone().call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e))
+                        service.call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e))
                     }
                     .boxed()
                 });

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -1,22 +1,21 @@
 use async_trait::async_trait;
+use futures::FutureExt;
 use http::header::HeaderValue;
-use hyper::server::conn::AddrStream;
-use hyper::service::Service;
-use hyper::service::{make_service_fn, service_fn};
+use tokio::net::TcpListener;
 use jsonrpsee::server::{
+    serve_with_graceful_shutdown, StopHandle, TowerServiceBuilder,
     middleware::rpc::RpcServiceBuilder, stop_channel, ws, BatchRequestConfig, RandomStringIdProvider, RpcModule,
-    ServerBuilder, ServerHandle,
+    ServerHandle,
 };
 use jsonrpsee::Methods;
 
-use serde::ser::StdError;
 use serde::Deserialize;
 
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{future::Future, net::SocketAddr};
 use tower::layer::layer_fn;
-use tower::ServiceBuilder;
+use tower::Service;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use super::{Extension, ExtensionRegistry};
@@ -113,54 +112,109 @@ impl SubwayServerBuilder {
     ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
         let config = self.config.clone();
 
-        let (stop_handle, server_handle) = stop_channel();
-        let handle = stop_handle.clone();
         let rpc_module = rpc_module_builder().await?;
 
-        // make_service handle each connection
-        let make_service = make_service_fn(move |socket: &AddrStream| {
-            let socket_ip = socket.remote_addr().ip().to_string();
+        let http_middleware = tower::ServiceBuilder::new()
+            .layer(cors_layer(config.cors.clone()).expect("Invalid CORS config"))
+            .layer(
+                ProxyGetRequestLayer::new(
+                    config
+                        .http_methods
+                        .iter()
+                        .map(|m| ProxyGetRequestMethod {
+                            path: m.path.clone(),
+                            method: m.method.clone(),
+                        })
+                        .collect(),
+                )
+                .expect("Invalid health config"),
+            );
 
-            let http_middleware: ServiceBuilder<_> = tower::ServiceBuilder::new()
-                .layer(cors_layer(config.cors.clone()).expect("Invalid CORS config"))
-                .layer(
-                    ProxyGetRequestLayer::new(
-                        config
-                            .http_methods
-                            .iter()
-                            .map(|m| ProxyGetRequestMethod {
-                                path: m.path.clone(),
-                                method: m.method.clone(),
-                            })
-                            .collect(),
-                    )
-                    .expect("Invalid health config"),
-                );
+        let batch_request_config = match config.max_batch_size {
+            Some(0) => BatchRequestConfig::Disabled,
+            Some(max_size) => BatchRequestConfig::Limit(max_size),
+            None => BatchRequestConfig::Unlimited,
+        };
 
-            let rpc_module = rpc_module.clone();
-            let stop_handle = stop_handle.clone();
-            let rate_limit_builder = rate_limit_builder.clone();
-            let rpc_method_weights = rpc_method_weights.clone();
-            let rpc_metrics = rpc_metrics.clone();
+        let ip_addr = std::net::IpAddr::from_str(&self.config.listen_address)?;
+        let addr = SocketAddr::new(ip_addr, self.config.port);
 
-            async move {
-                // service_fn handle each request
-                Ok::<_, Box<dyn StdError + Send + Sync>>(service_fn(move |req| {
+        let listener = TcpListener::bind(addr).await?;
+
+        // This state is cloned for every connection
+        // all these types based on Arcs and it should
+        // be relatively cheap to clone them.
+        //
+        // Make sure that nothing expensive is cloned here
+        // when doing this or use an `Arc`.
+        #[derive(Clone)]
+        struct PerConnection<RpcMiddleware, HttpMiddleware> {
+            methods: Methods,
+            stop_handle: StopHandle,
+            rpc_metrics: RpcMetrics,
+            svc_builder: TowerServiceBuilder<RpcMiddleware, HttpMiddleware>,
+            rate_limit_builder: Option<Arc<RateLimitBuilder>>,
+            rpc_method_weights: MethodWeights,
+        }
+
+        // Each RPC call/connection get its own `stop_handle`
+        // to able to determine whether the server has been stopped or not.
+        //
+        // To keep the server running the `server_handle`
+        // must be kept and it can also be used to stop the server.
+        let (stop_handle, server_handle) = stop_channel();
+
+        let per_conn = PerConnection {
+            methods: rpc_module.into(),
+            stop_handle: stop_handle.clone(),
+            rpc_metrics: rpc_metrics.clone(),
+            svc_builder: jsonrpsee::server::Server::builder()
+                .set_http_middleware(http_middleware)
+                .set_batch_request_config(batch_request_config)
+                .max_connections(config.max_connections)
+                .set_id_provider(RandomStringIdProvider::new(16))
+                .to_service_builder(),
+            rate_limit_builder,
+            rpc_method_weights,
+        };
+
+        tokio::spawn(async move {
+            loop {
+                // The `tokio::select!` macro is used to wait for either of the
+                // listeners to accept a new connection or for the server to be
+                // stopped.
+                let (sock, remote_addr) = tokio::select! {
+                    res = listener.accept() => {
+                        match res {
+                            Ok((stream, remote_addr)) => (stream, remote_addr),
+                            Err(e) => {
+                            tracing::error!("failed to accept v4 connection: {:?}", e);
+                                continue;
+                            }
+                        }
+                    }
+                    _ = per_conn.stop_handle.clone().shutdown() => break,
+                };
+
+                let per_conn2 = per_conn.clone();
+                // let call_metrics = rpc_metrics.clone().call_metrics();
+
+                // service_fn handle each connection
+                let svc = tower::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                    let PerConnection { methods, stop_handle, rpc_metrics, svc_builder , rate_limit_builder, rpc_method_weights} = per_conn2.clone();
+
                     let is_websocket = ws::is_upgrade_request(&req);
                     let protocol = if is_websocket { Protocol::Ws } else { Protocol::Http };
 
-                    let mut socket_ip = socket_ip.clone();
-                    let methods: Methods = rpc_module.clone().into();
-                    let stop_handle = stop_handle.clone();
-                    let http_middleware = http_middleware.clone();
-                    let rpc_metrics = rpc_metrics.clone();
-                    let call_metrics = rpc_metrics.call_metrics();
-
+                    let mut socket_ip = remote_addr.ip().to_string();
                     if let Some(true) = rate_limit_builder.as_ref().map(|r| r.use_xff()) {
                         socket_ip = req.xxf_ip().unwrap_or(socket_ip);
                     }
 
-                    let rpc_middleware = RpcServiceBuilder::new()
+                    let call_metrics = rpc_metrics.call_metrics();
+
+                    async move {
+                        let rpc_middleware = RpcServiceBuilder::new()
                         .option_layer(
                             rate_limit_builder
                                 .as_ref()
@@ -174,47 +228,28 @@ impl SubwayServerBuilder {
                         .option_layer(
                             call_metrics
                                 .as_ref()
-                                .map(|(a, b, c)| layer_fn(|s| PrometheusService::new(s, protocol, a, b, c))),
+                                .map(move |(a, b, c)| layer_fn(move |s| PrometheusService::new(s, protocol, a, b, c))),
                         );
 
-                    let batch_request_config = match config.max_batch_size {
-                        Some(0) => BatchRequestConfig::Disabled,
-                        Some(max_size) => BatchRequestConfig::Limit(max_size),
-                        None => BatchRequestConfig::Unlimited,
-                    };
+                        let mut service = svc_builder.set_rpc_middleware(rpc_middleware).build(methods, stop_handle);
 
-                    let service_builder = ServerBuilder::default()
-                        .set_rpc_middleware(rpc_middleware)
-                        .set_http_middleware(http_middleware)
-                        .max_connections(config.max_connections)
-                        .set_batch_request_config(batch_request_config)
-                        .set_id_provider(RandomStringIdProvider::new(16))
-                        .to_service_builder();
+                        if is_websocket {
+                            let on_ws_close = service.on_session_closed();
+                            rpc_metrics.ws_open();
+                            tokio::spawn(async move {
+                                on_ws_close.await;
+                                rpc_metrics.ws_closed();
+                            });
+                        }
 
-                    let mut service = service_builder.build(methods, stop_handle);
-
-                    if is_websocket {
-                        let on_ws_close = service.on_session_closed();
-                        rpc_metrics.ws_open();
-                        tokio::spawn(async move {
-                            on_ws_close.await;
-                            rpc_metrics.ws_closed();
-                        });
+                        service.clone().call(req).await.map_err(|e| anyhow::anyhow!("{:?}", e))
                     }
-                    service.call(req)
-                }))
+                    .boxed()
+                });
+
+                // tokio::spawn(serve_with_graceful_shutdown(sock, svc, stop_handle.clone().shutdown()));
+                tokio::spawn(serve_with_graceful_shutdown(sock, svc, stop_handle.clone().shutdown()));
             }
-        });
-
-        let ip_addr = std::net::IpAddr::from_str(&self.config.listen_address)?;
-        let addr = SocketAddr::new(ip_addr, self.config.port);
-
-        let server = hyper::Server::bind(&addr).serve(make_service);
-        let addr = server.local_addr();
-
-        tokio::spawn(async move {
-            let graceful = server.with_graceful_shutdown(async move { handle.shutdown().await });
-            graceful.await.unwrap()
         });
 
         Ok((addr, server_handle))

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -166,7 +166,7 @@ impl SubwayServerBuilder {
         let per_conn = PerConnection {
             methods: rpc_module.into(),
             stop_handle: stop_handle.clone(),
-            rpc_metrics: rpc_metrics,
+            rpc_metrics,
             svc_builder: jsonrpsee::server::Server::builder()
                 .set_http_middleware(http_middleware)
                 .set_batch_request_config(batch_request_config)

--- a/src/extensions/server/mod.rs
+++ b/src/extensions/server/mod.rs
@@ -139,6 +139,7 @@ impl SubwayServerBuilder {
         let addr = SocketAddr::new(ip_addr, self.config.port);
 
         let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
 
         // This state is cloned for every connection
         // all these types based on Arcs and it should

--- a/src/server.rs
+++ b/src/server.rs
@@ -81,7 +81,7 @@ pub async fn build(config: Config) -> anyhow::Result<SubwayServerHandle> {
 
                 let method_name = string_to_static_str(method.method.clone());
 
-                module.register_async_method(method_name, move |params, _| {
+                module.register_async_method(method_name, move |params, _, _| {
                     let method_middlewares = method_middlewares.clone();
                     async move {
                         let parsed = params.parse::<JsonValue>()?;
@@ -147,7 +147,7 @@ pub async fn build(config: Config) -> anyhow::Result<SubwayServerHandle> {
                     subscribe_name,
                     name,
                     unsubscribe_name,
-                    move |params, pending_sink, _| {
+                    move |params, pending_sink, _, _| {
                         let subscription_middlewares = subscription_middlewares.clone();
                         async move {
                             let parsed = params.parse::<JsonValue>()?;
@@ -204,7 +204,7 @@ pub async fn build(config: Config) -> anyhow::Result<SubwayServerHandle> {
 
             rpc_methods.sort();
 
-            module.register_method("rpc_methods", move |_, _| {
+            module.register_method("rpc_methods", move |_, _, _| {
                 Ok::<JsonValue, ErrorObjectOwned>(json!({
                     "version": 1,
                     "methods": rpc_methods
@@ -315,10 +315,10 @@ mod tests {
 
         let mut module = RpcModule::new(());
         module
-            .register_method(PHO, |_, _| Ok::<String, ErrorObjectOwned>(BAR.to_string()))
+            .register_method(PHO, |_, _, _| Ok::<String, ErrorObjectOwned>(BAR.to_string()))
             .unwrap();
         module
-            .register_async_method(TIMEOUT, |_, _| async {
+            .register_async_method(TIMEOUT, |_, _, _| async {
                 loop {
                     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 }


### PR DESCRIPTION
Resolve https://github.com/AcalaNetwork/subway/issues/185

The latest jsonrpsee release bumped its dependency hyper's version to v1.
https://github.com/paritytech/jsonrpsee/releases/tag/v0.23.0

This introduced low level api removal such as `hyper::service::make_service_fn`, and some others. See https://hyper.rs/guides/1/upgrading/. SubwayServerBuilder `build` function need to be updated accordingly.

Because we want to make use of a new feature added to jsonrpsee, hyper version upgrades is required as a first step.
https://github.com/paritytech/jsonrpsee/issues/1388
https://github.com/paritytech/jsonrpsee/pull/1389