### PR TITLE
feat: make `MethodWeights` cheap clone

### DIFF
--- a/src/extensions/rate_limit/weight.rs
+++ b/src/extensions/rate_limit/weight.rs
@@ -1,14 +1,11 @@
 use crate::config::RpcMethod;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Default)]
-pub struct MethodWeights(BTreeMap<String, u32>);
+pub struct MethodWeights(Arc<BTreeMap<String, u32>>);
 
 impl MethodWeights {
-    pub fn add(&mut self, method: &str, weight: u32) {
-        self.0.insert(method.to_owned(), weight);
-    }
-
     pub fn get(&self, method: &str) -> u32 {
         self.0.get(method).cloned().unwrap_or(1)
     }
@@ -16,10 +13,11 @@ impl MethodWeights {
 
 impl MethodWeights {
     pub fn from_config(methods: &[RpcMethod]) -> Self {
-        let mut weights = MethodWeights::default();
+        let mut weights = BTreeMap::default();
         for method in methods {
-            weights.add(&method.method, method.rate_limit_weight);
+            weights.insert(method.method.to_owned(), method.rate_limit_weight);
         }
-        weights
+
+        Self(Arc::new(weights))
     }
 }


### PR DESCRIPTION
See
```rust
        // This state is cloned for every connection
        // all these types based on Arcs and it should
        // be relatively cheap to clone them.
        //
        // Make sure that nothing expensive is cloned here
        // when doing this or use an `Arc`.
        #[derive(Clone)]
        struct PerConnection<RpcMiddleware, HttpMiddleware> {
            methods: Methods,
            stop_handle: StopHandle,
            rpc_metrics: RpcMetrics,
            svc_builder: TowerServiceBuilder<RpcMiddleware, HttpMiddleware>,
            rate_limit_builder: Option<Arc<RateLimitBuilder>>,
            rpc_method_weights: MethodWeights,
        }
```