### PR TITLE
Publish prebuilt musl binary on `v*` tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain with musl target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.88'
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build release binary
+        run: cargo build --release --locked --target x86_64-unknown-linux-musl
+
+      - name: Package binary
+        run: |
+          tar -czf subway-${{ github.ref_name }}-x86_64-unknown-linux-musl.tar.gz \
+            -C target/x86_64-unknown-linux-musl/release subway
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: subway-*.tar.gz
+          generate_release_notes: true


### PR DESCRIPTION
## Motivation

CI in [polkadot-fellows/runtimes#1180](https://github.com/polkadot-fellows/runtimes/pull/1180) and the equivalent workflow in [polkadot-ecosystem-tests](https://github.com/open-web3-stack/polkadot-ecosystem-tests) currently runs `cargo install --git https://github.com/AcalaNetwork/subway` on every run, which rebuilds Subway from source. That adds roughly four minutes per job, and there are now six sharded jobs per network. `Swatinem/rust-cache` softens the cost, but the cache still misses when Subway's HEAD moves or GitHub evicts the entry under size pressure.

A published binary would let those workflows replace `cargo install` with a `curl | tar -xz`, with no cache state on either side. `docker.yml` already triggers on `v*` tags, so this fits the existing release path: one tag, both a Docker image and a binary.

## Change

One new workflow file, `.github/workflows/release.yml`, triggered on tags matching `v*`. It builds a statically-linked `x86_64-unknown-linux-musl` binary using the toolchain pinned in `rust-toolchain.toml`, packages it as a `.tar.gz`, and attaches it to an auto-generated GitHub Release. No source changes.

The musl target keeps the binary portable across any Linux x86_64 host without coupling to a specific glibc. Other targets (macOS, aarch64) are easy to add later if needed.

## Notes

The first release needs a tag (e.g. `v0.1.0` matching the current `Cargo.toml` version). After that, releases are tag-and-push.