### PR TITLE
Expose per-upstream client timeouts and retries in `ClientConfig`

### DIFF
--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -217,6 +217,9 @@ fn config() -> Config {
                     format!("ws://{}", SERVER_TWO_ENDPOINT),
                 ],
                 shuffle_endpoints: false,
+                connection_timeout_seconds: None,
+                request_timeout_seconds: None,
+                retries: None,
             }),
             server: Some(ServerConfig {
                 listen_address: SUBWAY_SERVER_ADDR.to_string(),

--- a/src/extensions/client/mod.rs
+++ b/src/extensions/client/mod.rs
@@ -57,6 +57,18 @@ pub struct ClientConfig {
     pub endpoints: Vec<String>,
     #[serde(default = "bool_true")]
     pub shuffle_endpoints: bool,
+    /// Per-upstream request timeout in seconds. Defaults to 30s if unset.
+    /// Increase when upstream chains may take longer than 30s to respond to
+    /// heavy storage queries.
+    #[serde(default)]
+    pub request_timeout_seconds: Option<u64>,
+    /// Per-upstream connection (handshake) timeout in seconds. Defaults to 30s if unset.
+    #[serde(default)]
+    pub connection_timeout_seconds: Option<u64>,
+    /// Number of retries to apply per upstream call before rotating endpoints.
+    /// Defaults to the internal client default if unset.
+    #[serde(default)]
+    pub retries: Option<u32>,
 }
 
 fn validate_endpoint(endpoint: &str, _context: &()) -> garde::Result {
@@ -134,13 +146,16 @@ impl Extension for Client {
     type Config = ClientConfig;
 
     async fn from_config(config: &Self::Config, _registry: &ExtensionRegistry) -> Result<Self, anyhow::Error> {
-        if config.shuffle_endpoints {
+        let request_timeout = config.request_timeout_seconds.map(Duration::from_secs);
+        let connection_timeout = config.connection_timeout_seconds.map(Duration::from_secs);
+        let endpoints = if config.shuffle_endpoints {
             let mut endpoints = config.endpoints.clone();
             endpoints.shuffle(&mut thread_rng());
-            Ok(Self::new(endpoints, None, None, None)?)
+            endpoints
         } else {
-            Ok(Self::new(config.endpoints.clone(), None, None, None)?)
-        }
+            config.endpoints.clone()
+        };
+        Ok(Self::new(endpoints, request_timeout, connection_timeout, config.retries)?)
     }
 }
 

--- a/src/extensions/client/mod.rs
+++ b/src/extensions/client/mod.rs
@@ -155,7 +155,12 @@ impl Extension for Client {
         } else {
             config.endpoints.clone()
         };
-        Ok(Self::new(endpoints, request_timeout, connection_timeout, config.retries)?)
+        Ok(Self::new(
+            endpoints,
+            request_timeout,
+            connection_timeout,
+            config.retries,
+        )?)
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -254,6 +254,9 @@ mod tests {
                 client: Some(ClientConfig {
                     endpoints: vec![endpoint],
                     shuffle_endpoints: false,
+                    request_timeout_seconds: None,
+                    connection_timeout_seconds: None,
+                    retries: None,
                 }),
                 server: Some(ServerConfig {
                     listen_address: "127.0.0.1".to_string(),

--- a/src/tests/merge_subscription.rs
+++ b/src/tests/merge_subscription.rs
@@ -49,6 +49,9 @@ async fn merge_subscription_works() {
             client: Some(ClientConfig {
                 endpoints: vec![format!("ws://{addr}")],
                 shuffle_endpoints: false,
+                request_timeout_seconds: None,
+                connection_timeout_seconds: None,
+                retries: None,
             }),
             server: Some(ServerConfig {
                 listen_address: "0.0.0.0".to_string(),

--- a/src/tests/upstream.rs
+++ b/src/tests/upstream.rs
@@ -31,6 +31,9 @@ async fn upstream_error_propagate() {
             client: Some(ClientConfig {
                 endpoints: vec![format!("ws://{addr}")],
                 shuffle_endpoints: false,
+                request_timeout_seconds: None,
+                connection_timeout_seconds: None,
+                retries: None,
             }),
             server: Some(ServerConfig {
                 listen_address: "0.0.0.0".to_string(),


### PR DESCRIPTION
## Motivation

`Client::new` already accepts `request_timeout`, `connection_timeout`, and `retries` arguments, but `from_config` hardcodes all three to `None` because `ClientConfig` only exposes `endpoints` and `shuffle_endpoints`. As a result the only way to override the 30s per-upstream request timeout (and the 30s connection timeout, and the default retry count) is to construct `Client` directly in Rust, which isn't reachable from the YAML-driven config that downstream Subway deployments use.

The motivating case is heavy storage queries against slow public RPCs. When chopsticks issues a `chain_getBlockHash` (or similar) to Subway, the upstream chain doesn't always respond inside 30s. Subway cycles to the next endpoint, waits another 30s, and so on, never serving a response to chopsticks; the call eventually times out higher up the stack. Increasing chopsticks' own `rpc-timeout` doesn't help because Subway never gets past the 30s/endpoint cycle. This is what surfaced in [polkadot-fellows/runtimes#1180](https://github.com/polkadot-fellows/runtimes/pull/1180) / [open-web3-stack/polkadot-ecosystem-tests#621](https://github.com/open-web3-stack/polkadot-ecosystem-tests/pull/621) (Acala under sharded-CI load).

## Change

Adds three optional fields to `ClientConfig`:

- `request_timeout_seconds`
- `connection_timeout_seconds`
- `retries`

`from_config` plumbs them into `Client::new`. None of the existing defaults change when the fields are omitted (30s request timeout, 30s connection timeout, default retry count). The three test-internal `ClientConfig` literals are updated to set the new fields to `None` for parity with the previous behaviour.

Trivial diff, four files, no behavioural change in the absence of new YAML entries.
