### PR TITLE
Sync Cargo.lock before `cargo build --locked` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Install musl tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      # Sync `Cargo.lock` to the tag's `Cargo.toml` version before `--locked`
+      # enforcement. `scripts/release.sh` already runs `cargo check` to do
+      # this before pushing the tag, but a manually-bumped `Cargo.toml`
+      # pushed straight to a tag would otherwise leave `Cargo.lock` stale
+      # and the build step would fail silently (no asset uploaded).
+      - name: Sync Cargo.lock to workspace
+        run: cargo update --workspace
+
       - name: Build release binary
         run: cargo build --release --locked --target x86_64-unknown-linux-musl
 


### PR DESCRIPTION
## What happened

The release for `v0.1.1` was tagged with `Cargo.toml` bumped to `0.1.1` but with `Cargo.lock` still listing `0.1.0`.
`cargo build --release --locked` failed against the mismatch, `Publish GitHub Release` was skipped, and `v0.1.1` was created with no assets.

## Why this is needed

`scripts/release.sh` regenerates `Cargo.lock` (`cargo check`) before the tag is pushed, so the scripted path is already safe. The fix adds the same guarantee for any tag that bypasses the script (manual `Cargo.toml` edit + tag push, or any other lockfile drift): a `cargo update --workspace` step before the build keeps `Cargo.lock` in sync with the workspace `Cargo.toml`, and `--locked` still enforces no drift in transitive deps.

Without it, a mistake at tag time silently produces an empty release.
